### PR TITLE
feat: 週次目標の内容変更を可能にする

### DIFF
--- a/lib/pdca_cli/cli.rb
+++ b/lib/pdca_cli/cli.rb
@@ -575,7 +575,7 @@ module PdcaCli
         end
       end
 
-      desc "update", "週次目標の進捗を更新"
+      desc "update", "週次目標の進捗・内容を更新"
       option :json, type: :boolean, default: false, desc: "JSON形式で出力"
       def update
         client = CLI.require_auth_from(self)
@@ -592,19 +592,33 @@ module PdcaCli
 
           items = goal["items"]
           say ""
-          say "週次目標の進捗を更新します", :bold
+          say "週次目標を更新します", :bold
           say "#{goal['week_start_date']} ~ #{goal['week_end_date']}"
           say ""
 
           updated_items = items.map do |item|
             say "目標: #{item['content']} (現在: #{item['progress']}%)"
+
+            # 内容の変更
+            content_input = ask("内容変更 [Enterでスキップ]:")
+            content = if content_input.nil? || content_input.strip.empty?
+                        nil
+                      else
+                        content_input.strip
+                      end
+
+            # 進捗率の更新
             progress_input = ask("進捗率 [#{item['progress']}]:")
             progress = if progress_input.nil? || progress_input.strip.empty?
                          item["progress"]
                        else
                          [[progress_input.to_i, 0].max, 100].min
                        end
-            { id: item["id"], progress: progress }
+
+            updated = { id: item["id"], progress: progress }
+            updated[:content] = content if content
+            say ""
+            updated
           end
 
           result = client.update_weekly_goal(goal["id"], items: updated_items)
@@ -614,11 +628,11 @@ module PdcaCli
             say result.to_json
           else
             say ""
-            say "進捗を更新しました", :green
+            say "目標を更新しました", :green
             print_goal(updated_goal)
           end
         rescue Client::ApiError => e
-          CLI.error_output_from(self, e.body["error"] || "進捗の更新に失敗しました")
+          CLI.error_output_from(self, e.body["error"] || "目標の更新に失敗しました")
           exit 2
         end
       end


### PR DESCRIPTION
## 概要
Closes #3

`pdca goal update` コマンドで、進捗率だけでなく目標の内容（content）も変更できるようにしました。

## 変更内容
- 各目標に対して「内容変更」の入力欄を追加
- Enterでスキップすれば従来通り進捗のみ更新
- 内容を入力すれば `content` もAPIに送信
- API側は既に content 更新に対応済みのため、CLI側のみの修正

## スクリーンショット
<img width="479" height="290" alt="スクリーンショット 2026-04-02 21 29 40" src="https://github.com/user-attachments/assets/6d70f0f0-5d5c-4b79-9cfe-3e9b35ab1aa0" />
<img width="1150" height="340" alt="スクリーンショット 2026-04-02 21 30 10" src="https://github.com/user-attachments/assets/daf94e26-7f31-4079-8903-34283ccd3356" />


## テストプラン
- [x] 内容を変更 + 進捗も変更 → 両方反映される
- [x] `--json` オプションで正しいJSON出力