### PR TITLE
feat: 週次目標の上書き作成（--force オプション）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,9 @@ bin/pdca goal create --items "目標1" "目標2" --json
 # 今週の目標を確認
 bin/pdca goal current --json
 
+# 既存の目標を上書きして再作成（⚠️ 実行前に現在の目標を確認し、ユーザーに上書き確認を取ること）
+bin/pdca goal create --items "新目標" --force --json
+
 # 目標一覧
 bin/pdca goal list --json
 ```
@@ -64,6 +67,7 @@ bin/pdca report list --month YYYY-MM --json
 - 1日1報告の制約あり（同じ日付で再度createするとエラー、updateで更新）
 - 未来日はPlanのみ入力可能（Do/Check/Actionは無視される）
 - `--category_ids` は `plan show --json` で取得できるカテゴリIDを指定
+- `--force` による目標上書きは既存目標を削除するため、必ずユーザーに確認を取る
 
 ## 終了コード
 - 0: 成功

--- a/lib/pdca_cli/cli.rb
+++ b/lib/pdca_cli/cli.rb
@@ -460,6 +460,7 @@ module PdcaCli
       option :week_start, type: :string, desc: "週の開始日 (YYYY-MM-DD, デフォルト: 今週)"
       option :items, type: :array, desc: "目標リスト（スペース区切り）"
       option :category_ids, type: :array, desc: "カテゴリIDリスト（学習計画から選択）"
+      option :force, type: :boolean, default: false, desc: "既存の目標を上書きする"
       def create
         client = CLI.require_auth_from(self)
 
@@ -552,7 +553,7 @@ module PdcaCli
         end
 
         begin
-          result = client.create_weekly_goal(items: items, week_start: options[:week_start])
+          result = client.create_weekly_goal(items: items, week_start: options[:week_start], force: options[:force])
           goal = result["weekly_goal"]
 
           if options[:json]
@@ -564,7 +565,7 @@ module PdcaCli
         rescue Client::ApiError => e
           body = e.body
           if e.status == 409
-            CLI.error_output_from(self, body["error"] || "この週の目標は既に設定されています")
+            CLI.error_output_from(self, "この週の目標は既に設定されています。上書きするには --force オプションを使用してください。")
           elsif e.status == 422 && body["errors"]
             error_msg = body["errors"].map { |k, v| "#{k}: #{v.join(', ')}" }.join("\n")
             CLI.error_output_from(self, "バリデーションエラー\n#{error_msg}")

--- a/lib/pdca_cli/cli.rb
+++ b/lib/pdca_cli/cli.rb
@@ -539,6 +539,14 @@ module PdcaCli
             exit 0
           end
 
+          if options[:force]
+            say "⚠ 既存の週次目標が削除されます。", :yellow
+            unless yes?("続行しますか？ [Y/n]")
+              say "キャンセルしました。", :yellow
+              exit 0
+            end
+          end
+
           say ""
           say "--- 確認 ---"
           items.each_with_index do |item, i|

--- a/lib/pdca_cli/client.rb
+++ b/lib/pdca_cli/client.rb
@@ -70,9 +70,10 @@ module PdcaCli
       get("/api/v1/weekly_goals", query)
     end
 
-    def create_weekly_goal(items:, week_start: nil)
+    def create_weekly_goal(items:, week_start: nil, force: false)
       body = { items: items }
       body[:week_start] = week_start if week_start
+      body[:force] = true if force
       post("/api/v1/weekly_goals", body)
     end
 


### PR DESCRIPTION
## 概要
Closes #4

`pdca goal create --force` で既存の週次目標を上書き作成できるようにしました。

## 変更内容
- `goal create` に `--force` オプション追加
- `client.rb` に `force` パラメータの送信を追加
- 409エラー時に `--force` オプションの案内メッセージを表示

## API側の対応PR
koki-kato/pdca-app での対応PRと合わせてマージが必要です。

## テストプラン
- [x] `--force` なしで既存目標がある場合 → 409エラー + 案内メッセージ
- [x] `--force` ありで既存目標がある場合 → 上書き作成成功
- [x] `--force` ありで既存目標がない場合 → 通常通り作成成功