### PR TITLE
feat: 講師向け受講生一覧・詳細コマンド (#14)

### DIFF
--- a/lib/pdca_cli/cli.rb
+++ b/lib/pdca_cli/cli.rb
@@ -660,6 +660,85 @@ module PdcaCli
       end
     }
 
+    desc "student SUBCOMMAND", "【講師】受講生の管理"
+    subcommand "student", Class.new(Thor) { @_thor_name = "pdca student"
+
+      desc "list", "受講生一覧を表示"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :status, type: :string, desc: "ステータスでフィルタ (active/inactive)"
+      option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+      def list
+        client = CLI.require_auth_from(self)
+
+        begin
+          result = client.list_students(status: options[:status], team_id: options[:team_id])
+          students = result["students"]
+
+          if options[:json]
+            say result.to_json
+          elsif students.empty?
+            say "受講生が見つかりません。", :yellow
+          else
+            say "受講生一覧 (#{result['total']}名)", :bold
+            say ""
+            students.each do |s|
+              teams = s["teams"].join(", ")
+              latest = s["latest_report_date"] ? Date.parse(s["latest_report_date"]).iso8601 : "未報告"
+              say "  #{s['id']}  #{s['name']}  [#{teams}]  最終報告: #{latest}"
+            end
+          end
+        rescue Client::ApiError => e
+          if e.status == 403
+            CLI.error_output_from(self, "この操作は講師のみ実行可能です")
+          else
+            CLI.error_output_from(self, e.body["error"] || "受講生一覧の取得に失敗しました")
+          end
+          exit 1
+        end
+      end
+
+      desc "show", "受講生の詳細情報を表示"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :id, type: :numeric, required: true, desc: "受講生ID"
+      def show
+        client = CLI.require_auth_from(self)
+
+        begin
+          result = client.show_student(options[:id])
+          student = result["student"]
+
+          if options[:json]
+            say result.to_json
+          else
+            say "受講生詳細", :bold
+            say ""
+            say "  名前:     #{student['name']}"
+            say "  メール:   #{student['email']}"
+            say "  状態:     #{student['status']}"
+            say "  チーム:   #{student['teams'].join(', ')}"
+            latest = student['latest_report_date'] ? Date.parse(student['latest_report_date']).iso8601 : "未報告"
+            say "  最終報告: #{latest}"
+            say ""
+            if student["courses"] && !student["courses"].empty?
+              say "  コース:"
+              student["courses"].each do |c|
+                say "    - #{c['name']} (#{c['status']})"
+              end
+            end
+          end
+        rescue Client::ApiError => e
+          if e.status == 403
+            CLI.error_output_from(self, "この操作は講師のみ実行可能です")
+          elsif e.status == 404
+            CLI.error_output_from(self, "受講生が見つかりません")
+          else
+            CLI.error_output_from(self, e.body["error"] || "受講生情報の取得に失敗しました")
+          end
+          exit 1
+        end
+      end
+    }
+
     no_commands do
       def require_auth!
         config = Config.new

--- a/lib/pdca_cli/cli.rb
+++ b/lib/pdca_cli/cli.rb
@@ -682,7 +682,7 @@ module PdcaCli
             say "受講生一覧 (#{result['total']}名)", :bold
             say ""
             students.each do |s|
-              teams = s["teams"].join(", ")
+              teams = (s["teams"] || []).join(", ")
               latest = s["latest_report_date"] ? Date.parse(s["latest_report_date"]).iso8601 : "未報告"
               say "  #{s['id']}  #{s['name']}  [#{teams}]  最終報告: #{latest}"
             end
@@ -715,7 +715,7 @@ module PdcaCli
             say "  名前:     #{student['name']}"
             say "  メール:   #{student['email']}"
             say "  状態:     #{student['status']}"
-            say "  チーム:   #{student['teams'].join(', ')}"
+            say "  チーム:   #{(student['teams'] || []).join(', ')}"
             latest = student['latest_report_date'] ? Date.parse(student['latest_report_date']).iso8601 : "未報告"
             say "  最終報告: #{latest}"
             say ""

--- a/lib/pdca_cli/client.rb
+++ b/lib/pdca_cli/client.rb
@@ -94,6 +94,18 @@ module PdcaCli
       post("/api/v1/plan/categories", { name: name, estimated_hours: estimated_hours })
     end
 
+    # 講師向け: 受講生
+    def list_students(status: nil, team_id: nil)
+      query = {}
+      query[:status] = status if status
+      query[:team_id] = team_id if team_id
+      get("/api/v1/instructor/students", query)
+    end
+
+    def show_student(id)
+      get("/api/v1/instructor/students/#{id}")
+    end
+
     private
 
     def get(path, query = {})


### PR DESCRIPTION
## Summary
- `pdca student list` で受講生一覧を表示（`--status`, `--team_id`フィルタ対応）
- `pdca student show --id N` で受講生詳細を表示（コース情報含む）
- 講師権限チェック（403）、受講生未存在（404）のエラーハンドリング

## 対応Issue
Closes #14

## 備考
- Issue #14 では `--team "チーム名"` と記載されていたが、API側が `team_id`（数値）で受け取る設計のため `--team_id N` で実装。チーム名検索への変更は #29 で別途対応予定。

## Test plan
- [x] `bin/pdca student list --json` でJSON出力確認
- [x] `bin/pdca student list` で一覧表示確認
- [x] `bin/pdca student list --status active` でフィルタ確認
- [x] `bin/pdca student show --id 3` で詳細表示確認
- [ ] 受講生アカウントで実行→403エラー確認