### PR TITLE
feat: 講師向け進捗確認コマンド (#20)

### DIFF
--- a/lib/pdca_cli/cli.rb
+++ b/lib/pdca_cli/cli.rb
@@ -739,6 +739,85 @@ module PdcaCli
       end
     }
 
+    desc "progress SUBCOMMAND", "【講師】受講生の進捗確認"
+    subcommand "progress", Class.new(Thor) { @_thor_name = "pdca progress"
+
+      desc "list", "受講生の進捗一覧を表示"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+      def list
+        client = CLI.require_auth_from(self)
+
+        begin
+          result = client.list_progress(team_id: options[:team_id])
+          students = result["students"]
+
+          if options[:json]
+            say result.to_json
+          elsif students.empty?
+            say "受講生が見つかりません。", :yellow
+          else
+            say "進捗一覧", :bold
+            say ""
+            students.each do |s|
+              teams = (s["teams"] || []).join(", ")
+              say "  #{s['name']}  [#{teams}]"
+              (s["courses"] || []).each do |c|
+                bar = "=" * (c["completion_rate"] / 5) + "-" * (20 - c["completion_rate"] / 5)
+                say "    #{c['name']}  [#{bar}] #{c['completion_rate']}% (#{c['completed_categories']}/#{c['total_categories']})"
+              end
+            end
+          end
+        rescue Client::ApiError => e
+          if e.status == 403
+            CLI.error_output_from(self, "この操作は講師のみ実行可能です")
+          else
+            CLI.error_output_from(self, e.body["error"] || "進捗一覧の取得に失敗しました")
+          end
+          exit 1
+        end
+      end
+
+      desc "show", "受講生の進捗詳細を表示"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :id, type: :numeric, required: true, desc: "受講生ID"
+      def show
+        client = CLI.require_auth_from(self)
+
+        begin
+          result = client.show_progress(options[:id])
+          student = result["student"]
+          courses = result["courses"]
+
+          if options[:json]
+            say result.to_json
+          else
+            say "#{student['name']} の進捗", :bold
+            say ""
+            (courses || []).each do |c|
+              bar = "=" * (c["completion_rate"] / 5) + "-" * (20 - c["completion_rate"] / 5)
+              say "  #{c['name']}  [#{bar}] #{c['completion_rate']}%"
+              say ""
+              (c["categories"] || []).each do |cat|
+                mark = cat["completed"] ? "[x]" : "[ ]"
+                say "    #{mark} #{cat['name']}"
+              end
+              say ""
+            end
+          end
+        rescue Client::ApiError => e
+          if e.status == 403
+            CLI.error_output_from(self, "この操作は講師のみ実行可能です")
+          elsif e.status == 404
+            CLI.error_output_from(self, "受講生が見つかりません")
+          else
+            CLI.error_output_from(self, e.body["error"] || "進捗情報の取得に失敗しました")
+          end
+          exit 1
+        end
+      end
+    }
+
     no_commands do
       def require_auth!
         config = Config.new

--- a/lib/pdca_cli/client.rb
+++ b/lib/pdca_cli/client.rb
@@ -106,6 +106,17 @@ module PdcaCli
       get("/api/v1/instructor/students/#{id}")
     end
 
+    # 講師向け: 進捗確認
+    def list_progress(team_id: nil)
+      query = {}
+      query[:team_id] = team_id if team_id
+      get("/api/v1/instructor/progress", query)
+    end
+
+    def show_progress(id)
+      get("/api/v1/instructor/progress/#{id}")
+    end
+
     private
 
     def get(path, query = {})


### PR DESCRIPTION
## Summary
- `pdca progress list` で全受講生の進捗一覧を表示（プログレスバー付き、`--team_id`フィルタ対応）
- `pdca progress show --id N` で受講生個別の進捗詳細を表示（カテゴリ完了状況付き）
- 講師権限チェック（403）対応

## 対応Issue
Closes #20

## 備考
- Issue #20 では `--user-id` / `--team "チーム名"` と記載されていたが、I1（student）と統一して `--id` / `--team_id`（数値）で実装。チーム名検索への変更は #29 で別途対応予定。

## チェーンブランチ
`main` ← `feature/i1-instructor-students` ← **`feature/i7-instructor-progress`**
マージ順序: I1 → I7

## Test plan
- [x] `bin/pdca progress list --json` でJSON出力確認
- [x] `bin/pdca progress list` で進捗バー付き一覧確認
- [x] `bin/pdca progress show --id 3` でカテゴリ別詳細確認
- [ ] 受講生アカウントで実行→403エラー確認