### PR TITLE
feat: 講師向けダッシュボードコマンド (#15)

### DIFF
--- a/lib/pdca_cli/cli.rb
+++ b/lib/pdca_cli/cli.rb
@@ -818,6 +818,108 @@ module PdcaCli
       end
     }
 
+    desc "dashboard SUBCOMMAND", "【講師】報告状況ダッシュボード"
+    subcommand "dashboard", Class.new(Thor) { @_thor_name = "pdca dashboard"
+
+      desc "daily", "日別の報告状況を表示"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :date, type: :string, desc: "対象日 (YYYY-MM-DD, デフォルト: 昨日)"
+      option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+      option :status, type: :string, desc: "ステータスでフィルタ (green/yellow/red/not_submitted)"
+      def daily
+        client = CLI.require_auth_from(self)
+
+        begin
+          result = client.dashboard_daily(
+            date: options[:date],
+            team_id: options[:team_id],
+            status: options[:status]
+          )
+          summary = result["summary"]
+          students = result["students"]
+
+          if options[:json]
+            say result.to_json
+          else
+            say "日次報告状況 (#{Date.parse(result['date']).iso8601})", :bold
+            say ""
+            say "  提出: #{summary['submitted']}/#{summary['total']}名"
+            say "  G:#{summary['green']}  Y:#{summary['yellow']}  R:#{summary['red']}  未提出:#{summary['not_submitted']}"
+            say ""
+            students.each do |s|
+              if s["submitted"] && s["report"]
+                r = s["report"]
+                icon = case r["learning_status"]
+                       when "green" then "G"
+                       when "yellow" then "Y"
+                       when "red" then "R"
+                       end
+                plan = (r["learning_plan"] || "")[0..30]
+                say "  [#{icon}] #{s['name']}  #{plan}"
+              else
+                say "  [-] #{s['name']}  (未提出)", :yellow
+              end
+            end
+          end
+        rescue Client::ApiError => e
+          if e.status == 403
+            CLI.error_output_from(self, "この操作は講師のみ実行可能です")
+          else
+            CLI.error_output_from(self, e.body["error"] || "ダッシュボードの取得に失敗しました")
+          end
+          exit 1
+        end
+      end
+
+      desc "weekly", "週別の報告状況を表示"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :week_offset, type: :numeric, default: 0, desc: "週オフセット (0=今週, -1=先週)"
+      option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+      def weekly
+        client = CLI.require_auth_from(self)
+
+        begin
+          result = client.dashboard_weekly(
+            week_offset: options[:week_offset],
+            team_id: options[:team_id]
+          )
+          groups = result["meeting_day_groups"]
+
+          if options[:json]
+            say result.to_json
+          else
+            say "週次報告状況 (offset: #{result['week_offset']})", :bold
+            say ""
+            (groups || []).each do |group|
+              week_start = Date.parse(group["week_start"]).iso8601
+              week_end = Date.parse(group["week_end"]).iso8601
+              say "  #{group['meeting_day_name']} (#{week_start} ~ #{week_end})", :bold
+              say ""
+              (group["students"] || []).each do |s|
+                statuses = (s["daily_statuses"] || {}).map { |_date, st|
+                  case st
+                  when "green" then "G"
+                  when "yellow" then "Y"
+                  when "red" then "R"
+                  else "-"
+                  end
+                }.join(" ")
+                say "    #{s['name']}  [#{statuses}]"
+              end
+              say ""
+            end
+          end
+        rescue Client::ApiError => e
+          if e.status == 403
+            CLI.error_output_from(self, "この操作は講師のみ実行可能です")
+          else
+            CLI.error_output_from(self, e.body["error"] || "ダッシュボードの取得に失敗しました")
+          end
+          exit 1
+        end
+      end
+    }
+
     no_commands do
       def require_auth!
         config = Config.new

--- a/lib/pdca_cli/client.rb
+++ b/lib/pdca_cli/client.rb
@@ -117,6 +117,22 @@ module PdcaCli
       get("/api/v1/instructor/progress/#{id}")
     end
 
+    # 講師向け: ダッシュボード
+    def dashboard_daily(date: nil, team_id: nil, status: nil)
+      query = {}
+      query[:date] = date if date
+      query[:team_id] = team_id if team_id
+      query[:status] = status if status
+      get("/api/v1/instructor/dashboard/daily", query)
+    end
+
+    def dashboard_weekly(week_offset: nil, team_id: nil)
+      query = {}
+      query[:week_offset] = week_offset if week_offset
+      query[:team_id] = team_id if team_id
+      get("/api/v1/instructor/dashboard/weekly", query)
+    end
+
     private
 
     def get(path, query = {})


### PR DESCRIPTION
## Summary
- `pdca dashboard daily` で日別報告状況を表示（サマリー + 受講生別ステータス）
  - `--date`, `--status`, `--team_id` フィルタ対応
- `pdca dashboard weekly` で週別報告状況を表示（MTGグループ別、曜日ごとのG/Y/R/-マトリクス）
  - `--week_offset`, `--team_id` フィルタ対応
- 講師権限チェック（403）対応

## 対応Issue
Closes #15

## 備考
- Issue #15 では `--week YYYY-MM-DD` / `--team "チーム名"` と記載されていたが、API側の設計に合わせて `--week_offset`（数値） / `--team_id`（数値）で実装。チーム名検索への変更は #29 で別途対応予定。
- `weekly` の `daily_statuses` 日付順ソートは #28 (feature/i3-s1-comments) に含まれるレビュー修正で対応済み。

## チェーンブランチ
`main` ← `I1` ← `I7` ← **`feature/i2-instructor-dashboard`** ← `I3/S1`
マージ順序: I1 → I7 → I2 → I3/S1

## Test plan
- [x] `bin/pdca dashboard daily --json` でJSON出力確認
- [x] `bin/pdca dashboard daily --date 2026-02-10` でデータありの日次確認
- [x] `bin/pdca dashboard weekly --week_offset -9` で週次マトリクス確認
- [ ] 受講生アカウントで実行→403エラー確認