### PR TITLE
feat: コメント投稿・閲覧・削除コマンド (#16, #8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,49 @@ bin/pdca report update --date YYYY-MM-DD --do "..." --check "..." --action "..."
 bin/pdca report list --month YYYY-MM --json
 ```
 
+### 講師向け: 受講生管理
+```bash
+# 受講生一覧
+bin/pdca student list --json
+bin/pdca student list --status active --json
+
+# 受講生詳細
+bin/pdca student show --id 1 --json
+```
+
+### 講師向け: 進捗確認
+```bash
+# 全受講生の進捗一覧
+bin/pdca progress list --json
+
+# 受講生個別の進捗詳細
+bin/pdca progress show --id 1 --json
+```
+
+### 講師向け: ダッシュボード
+```bash
+# 日別報告状況（デフォルト: 昨日）
+bin/pdca dashboard daily --json
+bin/pdca dashboard daily --date 2026-04-11 --json
+bin/pdca dashboard daily --status not_submitted --json
+
+# 週別報告状況（デフォルト: 今週）
+bin/pdca dashboard weekly --json
+bin/pdca dashboard weekly --week_offset -1 --json
+```
+
+### コメント（講師・受講生共通）
+```bash
+# コメント一覧（report_idはreport list等で取得）
+bin/pdca comment list --report_id 1 --json
+
+# コメント投稿
+bin/pdca comment create --report_id 1 --content "コメント内容" --json
+
+# コメント削除（投稿者本人のみ）
+bin/pdca comment delete --id 1 --json
+```
+
 ## learning_status の値
 - `green`: 順調、問題なし
 - `yellow`: 少し詰まっているが対処できそう

--- a/lib/pdca_cli/cli.rb
+++ b/lib/pdca_cli/cli.rb
@@ -896,7 +896,7 @@ module PdcaCli
               say "  #{group['meeting_day_name']} (#{week_start} ~ #{week_end})", :bold
               say ""
               (group["students"] || []).each do |s|
-                statuses = (s["daily_statuses"] || {}).map { |_date, st|
+                statuses = (s["daily_statuses"] || {}).sort_by { |date, _| date }.map { |_date, st|
                   case st
                   when "green" then "G"
                   when "yellow" then "Y"
@@ -931,7 +931,7 @@ module PdcaCli
 
         begin
           result = client.list_comments(report_id: options[:report_id])
-          comments = result["comments"]
+          comments = result["comments"] || []
           ai_comment = result["ai_comment"]
 
           if options[:json]

--- a/lib/pdca_cli/cli.rb
+++ b/lib/pdca_cli/cli.rb
@@ -920,6 +920,120 @@ module PdcaCli
       end
     }
 
+    desc "comment SUBCOMMAND", "報告へのコメント操作"
+    subcommand "comment", Class.new(Thor) { @_thor_name = "pdca comment"
+
+      desc "list", "報告のコメントを表示"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :report_id, type: :numeric, required: true, desc: "報告ID"
+      def list
+        client = CLI.require_auth_from(self)
+
+        begin
+          result = client.list_comments(report_id: options[:report_id])
+          comments = result["comments"]
+          ai_comment = result["ai_comment"]
+
+          if options[:json]
+            say result.to_json
+          else
+            say "コメント (報告ID: #{options[:report_id]})", :bold
+            say ""
+            if ai_comment
+              say "  [AI] #{ai_comment['content']}"
+              say "       #{ai_comment['created_at']}"
+              say ""
+            end
+            if comments.empty?
+              say "  コメントはありません。", :yellow unless ai_comment
+            else
+              comments.each do |c|
+                role_label = c["user"]["role"] == "instructor" ? "講師" : "受講生"
+                say "  [#{role_label}] #{c['user']['name']} (ID: #{c['id']})"
+                say "  #{c['content']}"
+                say "  #{c['created_at']}"
+                say ""
+              end
+            end
+          end
+        rescue Client::ApiError => e
+          if e.status == 400
+            CLI.error_output_from(self, "report_idは必須です")
+          else
+            CLI.error_output_from(self, e.body["error"] || "コメントの取得に失敗しました")
+          end
+          exit 1
+        end
+      end
+
+      desc "create", "報告にコメントを投稿"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :report_id, type: :numeric, required: true, desc: "報告ID"
+      option :content, type: :string, desc: "コメント内容"
+      def create
+        client = CLI.require_auth_from(self)
+
+        content = options[:content]
+        unless content
+          content = ask("コメント内容:")
+          if content.nil? || content.strip.empty?
+            say "キャンセルしました。", :yellow
+            exit 0
+          end
+        end
+
+        begin
+          result = client.create_comment(report_id: options[:report_id], content: content)
+          comment = result["comment"]
+
+          if options[:json]
+            say result.to_json
+          else
+            say "コメントを投稿しました (ID: #{comment['id']})", :green
+          end
+        rescue Client::ApiError => e
+          if e.status == 422
+            errors = e.body["errors"]
+            if errors
+              error_msg = errors.map { |k, v| "#{k}: #{v.join(', ')}" }.join("\n")
+              CLI.error_output_from(self, "バリデーションエラー\n#{error_msg}")
+            else
+              CLI.error_output_from(self, e.body["error"] || "コメントの投稿に失敗しました")
+            end
+          else
+            CLI.error_output_from(self, e.body["error"] || "コメントの投稿に失敗しました")
+          end
+          exit 2
+        end
+      end
+
+      desc "delete", "コメントを削除"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :id, type: :numeric, required: true, desc: "コメントID"
+      def delete
+        client = CLI.require_auth_from(self)
+
+        begin
+          client.delete_comment(options[:id])
+
+          if options[:json]
+            say({ message: "コメントを削除しました" }.to_json)
+          else
+            say "コメントを削除しました (ID: #{options[:id]})", :green
+          end
+        rescue Client::ApiError => e
+          if e.status == 403
+            CLI.error_output_from(self, "削除権限がありません")
+          elsif e.status == 404
+            CLI.error_output_from(self, "コメントが見つかりません")
+          else
+            CLI.error_output_from(self, e.body["error"] || "コメントの削除に失敗しました")
+          end
+          exit 1
+        end
+      end
+    }
+
     no_commands do
       def require_auth!
         config = Config.new

--- a/lib/pdca_cli/client.rb
+++ b/lib/pdca_cli/client.rb
@@ -133,6 +133,19 @@ module PdcaCli
       get("/api/v1/instructor/dashboard/weekly", query)
     end
 
+    # コメント（講師・受講生共通）
+    def list_comments(report_id:)
+      get("/api/v1/comments", { report_id: report_id })
+    end
+
+    def create_comment(report_id:, content:)
+      post("/api/v1/comments", { report_id: report_id, content: content })
+    end
+
+    def delete_comment(id)
+      delete("/api/v1/comments/#{id}")
+    end
+
     private
 
     def get(path, query = {})
@@ -154,6 +167,12 @@ module PdcaCli
       request = Net::HTTP::Patch.new(uri.request_uri)
       request.body = body.to_json
       request["Content-Type"] = "application/json"
+      execute(uri, request)
+    end
+
+    def delete(path)
+      uri = build_uri(path)
+      request = Net::HTTP::Delete.new(uri.request_uri)
       execute(uri, request)
     end
 
@@ -188,7 +207,7 @@ module PdcaCli
       http.read_timeout = 30
 
       response = http.request(request)
-      body = response.body ? JSON.parse(response.body) : {}
+      body = (response.body && !response.body.empty?) ? JSON.parse(response.body) : {}
 
       case response.code.to_i
       when 200..299


### PR DESCRIPTION
## Summary
- `pdca comment list --report_id N` でコメント一覧を表示（AIコメント + ユーザーコメント）
- `pdca comment create --report_id N --content "..."` でコメント投稿（content省略時は対話入力）
- `pdca comment delete --id N` でコメント削除（投稿者本人のみ）
- 講師は全報告にアクセス可、受講生は自分の報告のみアクセス可
- client.rbに `delete` HTTPメソッド追加、`execute` のレスポンスボディパース安全化
- レビュー指摘対応: commentsのnilガード、dashboard weeklyの日付順ソート

## 対応Issue
Closes #16
Closes #8

## チェーンブランチ
`main` ← `I1` ← `I7` ← `I2` ← **`feature/i3-s1-comments`**
マージ順序: #25 → #26 → #27 → #28（`--delete-branch` なし）

## Test plan
- [x] `bin/pdca comment list --report_id 238 --json` でJSON出力確認
- [x] `bin/pdca comment create --report_id 238 --content "テスト" --json` で投稿確認
- [x] `bin/pdca comment delete --id 13 --json` で削除確認
- [x] 削除後のlist確認
- [ ] 受講生アカウントで自分の報告のコメント操作確認（S1）
- [ ] 他人の報告へのアクセス制限確認
- [ ] 同一報告への重複コメント→422エラー確認