### PR TITLE
feat: 講師向けCLI機能の残りをmainに統合（I7/I2/I3+S1）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,49 @@ bin/pdca report update --date YYYY-MM-DD --do "..." --check "..." --action "..."
 bin/pdca report list --month YYYY-MM --json
 ```
 
+### 講師向け: 受講生管理
+```bash
+# 受講生一覧
+bin/pdca student list --json
+bin/pdca student list --status active --json
+
+# 受講生詳細
+bin/pdca student show --id 1 --json
+```
+
+### 講師向け: 進捗確認
+```bash
+# 全受講生の進捗一覧
+bin/pdca progress list --json
+
+# 受講生個別の進捗詳細
+bin/pdca progress show --id 1 --json
+```
+
+### 講師向け: ダッシュボード
+```bash
+# 日別報告状況（デフォルト: 昨日）
+bin/pdca dashboard daily --json
+bin/pdca dashboard daily --date 2026-04-11 --json
+bin/pdca dashboard daily --status not_submitted --json
+
+# 週別報告状況（デフォルト: 今週）
+bin/pdca dashboard weekly --json
+bin/pdca dashboard weekly --week_offset -1 --json
+```
+
+### コメント（講師・受講生共通）
+```bash
+# コメント一覧（report_idはreport list等で取得）
+bin/pdca comment list --report_id 1 --json
+
+# コメント投稿
+bin/pdca comment create --report_id 1 --content "コメント内容" --json
+
+# コメント削除（投稿者本人のみ）
+bin/pdca comment delete --id 1 --json
+```
+
 ## learning_status の値
 - `green`: 順調、問題なし
 - `yellow`: 少し詰まっているが対処できそう

--- a/lib/pdca_cli/cli.rb
+++ b/lib/pdca_cli/cli.rb
@@ -818,6 +818,108 @@ module PdcaCli
       end
     }
 
+    desc "dashboard SUBCOMMAND", "【講師】報告状況ダッシュボード"
+    subcommand "dashboard", Class.new(Thor) { @_thor_name = "pdca dashboard"
+
+      desc "daily", "日別の報告状況を表示"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :date, type: :string, desc: "対象日 (YYYY-MM-DD, デフォルト: 昨日)"
+      option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+      option :status, type: :string, desc: "ステータスでフィルタ (green/yellow/red/not_submitted)"
+      def daily
+        client = CLI.require_auth_from(self)
+
+        begin
+          result = client.dashboard_daily(
+            date: options[:date],
+            team_id: options[:team_id],
+            status: options[:status]
+          )
+          summary = result["summary"]
+          students = result["students"]
+
+          if options[:json]
+            say result.to_json
+          else
+            say "日次報告状況 (#{Date.parse(result['date']).iso8601})", :bold
+            say ""
+            say "  提出: #{summary['submitted']}/#{summary['total']}名"
+            say "  G:#{summary['green']}  Y:#{summary['yellow']}  R:#{summary['red']}  未提出:#{summary['not_submitted']}"
+            say ""
+            students.each do |s|
+              if s["submitted"] && s["report"]
+                r = s["report"]
+                icon = case r["learning_status"]
+                       when "green" then "G"
+                       when "yellow" then "Y"
+                       when "red" then "R"
+                       end
+                plan = (r["learning_plan"] || "")[0..30]
+                say "  [#{icon}] #{s['name']}  #{plan}"
+              else
+                say "  [-] #{s['name']}  (未提出)", :yellow
+              end
+            end
+          end
+        rescue Client::ApiError => e
+          if e.status == 403
+            CLI.error_output_from(self, "この操作は講師のみ実行可能です")
+          else
+            CLI.error_output_from(self, e.body["error"] || "ダッシュボードの取得に失敗しました")
+          end
+          exit 1
+        end
+      end
+
+      desc "weekly", "週別の報告状況を表示"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :week_offset, type: :numeric, default: 0, desc: "週オフセット (0=今週, -1=先週)"
+      option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+      def weekly
+        client = CLI.require_auth_from(self)
+
+        begin
+          result = client.dashboard_weekly(
+            week_offset: options[:week_offset],
+            team_id: options[:team_id]
+          )
+          groups = result["meeting_day_groups"]
+
+          if options[:json]
+            say result.to_json
+          else
+            say "週次報告状況 (offset: #{result['week_offset']})", :bold
+            say ""
+            (groups || []).each do |group|
+              week_start = Date.parse(group["week_start"]).iso8601
+              week_end = Date.parse(group["week_end"]).iso8601
+              say "  #{group['meeting_day_name']} (#{week_start} ~ #{week_end})", :bold
+              say ""
+              (group["students"] || []).each do |s|
+                statuses = (s["daily_statuses"] || {}).map { |_date, st|
+                  case st
+                  when "green" then "G"
+                  when "yellow" then "Y"
+                  when "red" then "R"
+                  else "-"
+                  end
+                }.join(" ")
+                say "    #{s['name']}  [#{statuses}]"
+              end
+              say ""
+            end
+          end
+        rescue Client::ApiError => e
+          if e.status == 403
+            CLI.error_output_from(self, "この操作は講師のみ実行可能です")
+          else
+            CLI.error_output_from(self, e.body["error"] || "ダッシュボードの取得に失敗しました")
+          end
+          exit 1
+        end
+      end
+    }
+
     no_commands do
       def require_auth!
         config = Config.new

--- a/lib/pdca_cli/cli.rb
+++ b/lib/pdca_cli/cli.rb
@@ -896,7 +896,7 @@ module PdcaCli
               say "  #{group['meeting_day_name']} (#{week_start} ~ #{week_end})", :bold
               say ""
               (group["students"] || []).each do |s|
-                statuses = (s["daily_statuses"] || {}).map { |_date, st|
+                statuses = (s["daily_statuses"] || {}).sort_by { |date, _| date }.map { |_date, st|
                   case st
                   when "green" then "G"
                   when "yellow" then "Y"
@@ -931,7 +931,7 @@ module PdcaCli
 
         begin
           result = client.list_comments(report_id: options[:report_id])
-          comments = result["comments"]
+          comments = result["comments"] || []
           ai_comment = result["ai_comment"]
 
           if options[:json]

--- a/lib/pdca_cli/cli.rb
+++ b/lib/pdca_cli/cli.rb
@@ -739,6 +739,85 @@ module PdcaCli
       end
     }
 
+    desc "progress SUBCOMMAND", "【講師】受講生の進捗確認"
+    subcommand "progress", Class.new(Thor) { @_thor_name = "pdca progress"
+
+      desc "list", "受講生の進捗一覧を表示"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+      def list
+        client = CLI.require_auth_from(self)
+
+        begin
+          result = client.list_progress(team_id: options[:team_id])
+          students = result["students"]
+
+          if options[:json]
+            say result.to_json
+          elsif students.empty?
+            say "受講生が見つかりません。", :yellow
+          else
+            say "進捗一覧", :bold
+            say ""
+            students.each do |s|
+              teams = (s["teams"] || []).join(", ")
+              say "  #{s['name']}  [#{teams}]"
+              (s["courses"] || []).each do |c|
+                bar = "=" * (c["completion_rate"] / 5) + "-" * (20 - c["completion_rate"] / 5)
+                say "    #{c['name']}  [#{bar}] #{c['completion_rate']}% (#{c['completed_categories']}/#{c['total_categories']})"
+              end
+            end
+          end
+        rescue Client::ApiError => e
+          if e.status == 403
+            CLI.error_output_from(self, "この操作は講師のみ実行可能です")
+          else
+            CLI.error_output_from(self, e.body["error"] || "進捗一覧の取得に失敗しました")
+          end
+          exit 1
+        end
+      end
+
+      desc "show", "受講生の進捗詳細を表示"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :id, type: :numeric, required: true, desc: "受講生ID"
+      def show
+        client = CLI.require_auth_from(self)
+
+        begin
+          result = client.show_progress(options[:id])
+          student = result["student"]
+          courses = result["courses"]
+
+          if options[:json]
+            say result.to_json
+          else
+            say "#{student['name']} の進捗", :bold
+            say ""
+            (courses || []).each do |c|
+              bar = "=" * (c["completion_rate"] / 5) + "-" * (20 - c["completion_rate"] / 5)
+              say "  #{c['name']}  [#{bar}] #{c['completion_rate']}%"
+              say ""
+              (c["categories"] || []).each do |cat|
+                mark = cat["completed"] ? "[x]" : "[ ]"
+                say "    #{mark} #{cat['name']}"
+              end
+              say ""
+            end
+          end
+        rescue Client::ApiError => e
+          if e.status == 403
+            CLI.error_output_from(self, "この操作は講師のみ実行可能です")
+          elsif e.status == 404
+            CLI.error_output_from(self, "受講生が見つかりません")
+          else
+            CLI.error_output_from(self, e.body["error"] || "進捗情報の取得に失敗しました")
+          end
+          exit 1
+        end
+      end
+    }
+
     no_commands do
       def require_auth!
         config = Config.new

--- a/lib/pdca_cli/cli.rb
+++ b/lib/pdca_cli/cli.rb
@@ -920,6 +920,120 @@ module PdcaCli
       end
     }
 
+    desc "comment SUBCOMMAND", "報告へのコメント操作"
+    subcommand "comment", Class.new(Thor) { @_thor_name = "pdca comment"
+
+      desc "list", "報告のコメントを表示"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :report_id, type: :numeric, required: true, desc: "報告ID"
+      def list
+        client = CLI.require_auth_from(self)
+
+        begin
+          result = client.list_comments(report_id: options[:report_id])
+          comments = result["comments"]
+          ai_comment = result["ai_comment"]
+
+          if options[:json]
+            say result.to_json
+          else
+            say "コメント (報告ID: #{options[:report_id]})", :bold
+            say ""
+            if ai_comment
+              say "  [AI] #{ai_comment['content']}"
+              say "       #{ai_comment['created_at']}"
+              say ""
+            end
+            if comments.empty?
+              say "  コメントはありません。", :yellow unless ai_comment
+            else
+              comments.each do |c|
+                role_label = c["user"]["role"] == "instructor" ? "講師" : "受講生"
+                say "  [#{role_label}] #{c['user']['name']} (ID: #{c['id']})"
+                say "  #{c['content']}"
+                say "  #{c['created_at']}"
+                say ""
+              end
+            end
+          end
+        rescue Client::ApiError => e
+          if e.status == 400
+            CLI.error_output_from(self, "report_idは必須です")
+          else
+            CLI.error_output_from(self, e.body["error"] || "コメントの取得に失敗しました")
+          end
+          exit 1
+        end
+      end
+
+      desc "create", "報告にコメントを投稿"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :report_id, type: :numeric, required: true, desc: "報告ID"
+      option :content, type: :string, desc: "コメント内容"
+      def create
+        client = CLI.require_auth_from(self)
+
+        content = options[:content]
+        unless content
+          content = ask("コメント内容:")
+          if content.nil? || content.strip.empty?
+            say "キャンセルしました。", :yellow
+            exit 0
+          end
+        end
+
+        begin
+          result = client.create_comment(report_id: options[:report_id], content: content)
+          comment = result["comment"]
+
+          if options[:json]
+            say result.to_json
+          else
+            say "コメントを投稿しました (ID: #{comment['id']})", :green
+          end
+        rescue Client::ApiError => e
+          if e.status == 422
+            errors = e.body["errors"]
+            if errors
+              error_msg = errors.map { |k, v| "#{k}: #{v.join(', ')}" }.join("\n")
+              CLI.error_output_from(self, "バリデーションエラー\n#{error_msg}")
+            else
+              CLI.error_output_from(self, e.body["error"] || "コメントの投稿に失敗しました")
+            end
+          else
+            CLI.error_output_from(self, e.body["error"] || "コメントの投稿に失敗しました")
+          end
+          exit 2
+        end
+      end
+
+      desc "delete", "コメントを削除"
+      option :json, type: :boolean, default: false, desc: "JSON形式で出力"
+      option :id, type: :numeric, required: true, desc: "コメントID"
+      def delete
+        client = CLI.require_auth_from(self)
+
+        begin
+          client.delete_comment(options[:id])
+
+          if options[:json]
+            say({ message: "コメントを削除しました" }.to_json)
+          else
+            say "コメントを削除しました (ID: #{options[:id]})", :green
+          end
+        rescue Client::ApiError => e
+          if e.status == 403
+            CLI.error_output_from(self, "削除権限がありません")
+          elsif e.status == 404
+            CLI.error_output_from(self, "コメントが見つかりません")
+          else
+            CLI.error_output_from(self, e.body["error"] || "コメントの削除に失敗しました")
+          end
+          exit 1
+        end
+      end
+    }
+
     no_commands do
       def require_auth!
         config = Config.new

--- a/lib/pdca_cli/client.rb
+++ b/lib/pdca_cli/client.rb
@@ -106,6 +106,17 @@ module PdcaCli
       get("/api/v1/instructor/students/#{id}")
     end
 
+    # 講師向け: 進捗確認
+    def list_progress(team_id: nil)
+      query = {}
+      query[:team_id] = team_id if team_id
+      get("/api/v1/instructor/progress", query)
+    end
+
+    def show_progress(id)
+      get("/api/v1/instructor/progress/#{id}")
+    end
+
     private
 
     def get(path, query = {})

--- a/lib/pdca_cli/client.rb
+++ b/lib/pdca_cli/client.rb
@@ -117,6 +117,22 @@ module PdcaCli
       get("/api/v1/instructor/progress/#{id}")
     end
 
+    # 講師向け: ダッシュボード
+    def dashboard_daily(date: nil, team_id: nil, status: nil)
+      query = {}
+      query[:date] = date if date
+      query[:team_id] = team_id if team_id
+      query[:status] = status if status
+      get("/api/v1/instructor/dashboard/daily", query)
+    end
+
+    def dashboard_weekly(week_offset: nil, team_id: nil)
+      query = {}
+      query[:week_offset] = week_offset if week_offset
+      query[:team_id] = team_id if team_id
+      get("/api/v1/instructor/dashboard/weekly", query)
+    end
+
     private
 
     def get(path, query = {})

--- a/lib/pdca_cli/client.rb
+++ b/lib/pdca_cli/client.rb
@@ -133,6 +133,19 @@ module PdcaCli
       get("/api/v1/instructor/dashboard/weekly", query)
     end
 
+    # コメント（講師・受講生共通）
+    def list_comments(report_id:)
+      get("/api/v1/comments", { report_id: report_id })
+    end
+
+    def create_comment(report_id:, content:)
+      post("/api/v1/comments", { report_id: report_id, content: content })
+    end
+
+    def delete_comment(id)
+      delete("/api/v1/comments/#{id}")
+    end
+
     private
 
     def get(path, query = {})
@@ -154,6 +167,12 @@ module PdcaCli
       request = Net::HTTP::Patch.new(uri.request_uri)
       request.body = body.to_json
       request["Content-Type"] = "application/json"
+      execute(uri, request)
+    end
+
+    def delete(path)
+      uri = build_uri(path)
+      request = Net::HTTP::Delete.new(uri.request_uri)
       execute(uri, request)
     end
 
@@ -188,7 +207,7 @@ module PdcaCli
       http.read_timeout = 30
 
       response = http.request(request)
-      body = response.body ? JSON.parse(response.body) : {}
+      body = (response.body && !response.body.empty?) ? JSON.parse(response.body) : {}
 
       case response.code.to_i
       when 200..299


### PR DESCRIPTION
## Summary
チェーンブランチ構成でPR #26〜#28 が各ベースブランチにマージされたが、mainには #25（I1）のみ反映されていた。残りの3機能をmainに統合する。

- `pdca progress list/show` — 進捗確認（#26, #20）
- `pdca dashboard daily/weekly` — ダッシュボード（#27, #15）
- `pdca comment list/create/delete` — コメント（#28, #16, #8）
- CLAUDE.md追記、レビュー指摘修正含む

## 経緯
PR #25→#26→#27→#28 のチェーンブランチ構成で順にマージしたが、#26〜#28は各ベースブランチにマージされるのみでmainに伝播しなかった。