### PR TITLE
feat: 講師向けコマンドのチームフィルタを --team（名前指定）に変更 (#29)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ bin/pdca comment delete --id 1 --json
 - 未来日はPlanのみ入力可能（Do/Check/Actionは無視される）
 - `--category_ids` は `plan show --json` で取得できるカテゴリIDを指定
 - `--force` による目標上書きは既存目標を削除するため、必ずユーザーに確認を取る
+- `--team` はチーム名の完全一致でフィルタ（部分一致不可）。チーム名は `student list --json` で確認可能
 
 ## 終了コード
 - 0: 成功

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ bin/pdca report list --month YYYY-MM --json
 # 受講生一覧
 bin/pdca student list --json
 bin/pdca student list --status active --json
+bin/pdca student list --team "Aチーム" --json
 
 # 受講生詳細
 bin/pdca student show --id 1 --json
@@ -70,6 +71,7 @@ bin/pdca student show --id 1 --json
 ```bash
 # 全受講生の進捗一覧
 bin/pdca progress list --json
+bin/pdca progress list --team "Aチーム" --json
 
 # 受講生個別の進捗詳細
 bin/pdca progress show --id 1 --json
@@ -81,10 +83,12 @@ bin/pdca progress show --id 1 --json
 bin/pdca dashboard daily --json
 bin/pdca dashboard daily --date 2026-04-11 --json
 bin/pdca dashboard daily --status not_submitted --json
+bin/pdca dashboard daily --team "Aチーム" --json
 
 # 週別報告状況（デフォルト: 今週）
 bin/pdca dashboard weekly --json
 bin/pdca dashboard weekly --week_offset -1 --json
+bin/pdca dashboard weekly --team "Aチーム" --json
 ```
 
 ### コメント（講師・受講生共通）

--- a/docs/superpowers/plans/2026-04-17-team-name-filter.md
+++ b/docs/superpowers/plans/2026-04-17-team-name-filter.md
@@ -1,0 +1,428 @@
+# チームフィルタ名前指定化 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 講師向けコマンド（student/progress/dashboard）のチームフィルタを `--team_id N` から `--team "チーム名"` に完全置換する。
+
+**Architecture:** CLI側は `--team_id` を `--team` に置換し、API呼び出し時は `team_name` クエリパラメータに変換して送信する。API側（`occ_pdca_app`）は別PRで `team_name` パラメータ受付を追加（本プランの対象外）。
+
+**Tech Stack:** Ruby 3.0+, Thor 1.3, Faraday（既存のHTTPクライアント）
+
+**対応Issue:** [#29](https://github.com/koki-kato/pdca-app/issues/29)
+
+**関連スペック:** [docs/superpowers/specs/2026-04-17-team-name-filter-design.md](../specs/2026-04-17-team-name-filter-design.md)
+
+---
+
+## 前提・リリース順序（重要）
+
+**API側 PR のマージ・本番デプロイが先**、CLI側 PR のマージが後。
+
+順序を間違えると、新CLI（`team_name` を送信）が旧API（`team_name` を受け付けない）を叩いてフィルタが効かず全件返る不具合になる。
+
+API側の変更内容:
+- `app/controllers/api/v1/instructor/students_controller.rb`
+- `app/controllers/api/v1/instructor/progress_controller.rb`
+- `app/controllers/api/v1/instructor/dashboard_controller.rb`
+- 各コントローラで `params[:team_name]` を joins(:team).where(teams: { name: ... }) で絞り込み
+- `params[:team_id]` は既存のまま残す（後方互換）
+
+---
+
+## ファイル構造
+
+### 変更ファイル
+
+| ファイル | 変更内容 | 責務 |
+|---------|---------|------|
+| `lib/pdca_cli/client.rb` | 4メソッドのパラメータ名 `team_id` → `team` に変更、APIクエリは `team_name` に変換 | APIクライアント層 |
+| `lib/pdca_cli/cli.rb` | 4コマンドのThorオプション `--team_id` → `--team`、クライアント呼び出し調整 | CLIインターフェース層 |
+| `CLAUDE.md` | 講師向けコマンドの使用例を `--team_id N` から `--team "チーム名"` に更新 | ドキュメント |
+
+### テストについて
+
+既存プロジェクトにRSpec等のテストディレクトリ・依存関係が存在しないため、CLI側はテストコードは書かず**手動動作確認**で検証する（既存の実装パターンに従う：#14, #15, #20 など過去のfeatコミットもテストなし）。
+
+API側は `occ_pdca_app` の既存テスト規約（RSpec request spec）に従って別PR内で追加する。
+
+---
+
+## Task 1: client.rb の4メソッドを `team_id` → `team` に変更
+
+**Files:**
+- Modify: `lib/pdca_cli/client.rb:98-134`
+
+- [ ] **Step 1: `list_students` の変更**
+
+`lib/pdca_cli/client.rb:98-103` を以下に変更:
+
+```ruby
+# 講師向け: 受講生
+def list_students(status: nil, team: nil)
+  query = {}
+  query[:status] = status if status
+  query[:team_name] = team if team && !team.empty?
+  get("/api/v1/instructor/students", query)
+end
+```
+
+- [ ] **Step 2: `list_progress` の変更**
+
+`lib/pdca_cli/client.rb:110-114` を以下に変更:
+
+```ruby
+# 講師向け: 進捗確認
+def list_progress(team: nil)
+  query = {}
+  query[:team_name] = team if team && !team.empty?
+  get("/api/v1/instructor/progress", query)
+end
+```
+
+- [ ] **Step 3: `dashboard_daily` の変更**
+
+`lib/pdca_cli/client.rb:121-127` を以下に変更:
+
+```ruby
+def dashboard_daily(date: nil, team: nil, status: nil)
+  query = {}
+  query[:date] = date if date
+  query[:team_name] = team if team && !team.empty?
+  query[:status] = status if status
+  get("/api/v1/instructor/dashboard/daily", query)
+end
+```
+
+- [ ] **Step 4: `dashboard_weekly` の変更**
+
+`lib/pdca_cli/client.rb:129-134` を以下に変更:
+
+```ruby
+def dashboard_weekly(week_offset: nil, team: nil)
+  query = {}
+  query[:week_offset] = week_offset if week_offset
+  query[:team_name] = team if team && !team.empty?
+  get("/api/v1/instructor/dashboard/weekly", query)
+end
+```
+
+- [ ] **Step 5: Ruby構文チェック**
+
+```bash
+ruby -c lib/pdca_cli/client.rb
+```
+
+Expected: `Syntax OK`
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add lib/pdca_cli/client.rb
+git commit -m "refactor: client.rb のチームフィルタを team_id → team に変更 (#29)"
+```
+
+---
+
+## Task 2: cli.rb の4コマンドのオプションを `--team_id` → `--team` に変更
+
+**Files:**
+- Modify: `lib/pdca_cli/cli.rb:669, 674`（student list）
+- Modify: `lib/pdca_cli/cli.rb:747, 752`（progress list）
+- Modify: `lib/pdca_cli/cli.rb:827, 835`（dashboard daily）
+- Modify: `lib/pdca_cli/cli.rb:877, 884`（dashboard weekly）
+
+- [ ] **Step 1: `student list` のオプション変更**
+
+`lib/pdca_cli/cli.rb:669` を:
+```ruby
+option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+```
+に以下に変更:
+```ruby
+option :team, type: :string, desc: "チーム名でフィルタ（完全一致）"
+```
+
+`lib/pdca_cli/cli.rb:674` を:
+```ruby
+result = client.list_students(status: options[:status], team_id: options[:team_id])
+```
+に以下に変更:
+```ruby
+result = client.list_students(status: options[:status], team: options[:team])
+```
+
+- [ ] **Step 2: `progress list` のオプション変更**
+
+`lib/pdca_cli/cli.rb:747` を:
+```ruby
+option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+```
+に以下に変更:
+```ruby
+option :team, type: :string, desc: "チーム名でフィルタ（完全一致）"
+```
+
+`lib/pdca_cli/cli.rb:752` を:
+```ruby
+result = client.list_progress(team_id: options[:team_id])
+```
+に以下に変更:
+```ruby
+result = client.list_progress(team: options[:team])
+```
+
+- [ ] **Step 3: `dashboard daily` のオプション変更**
+
+`lib/pdca_cli/cli.rb:827` を:
+```ruby
+option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+```
+に以下に変更:
+```ruby
+option :team, type: :string, desc: "チーム名でフィルタ（完全一致）"
+```
+
+`lib/pdca_cli/cli.rb:833-837` の `client.dashboard_daily(...)` 呼び出しを以下に変更:
+```ruby
+result = client.dashboard_daily(
+  date: options[:date],
+  team: options[:team],
+  status: options[:status]
+)
+```
+
+- [ ] **Step 4: `dashboard weekly` のオプション変更**
+
+`lib/pdca_cli/cli.rb:877` を:
+```ruby
+option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+```
+に以下に変更:
+```ruby
+option :team, type: :string, desc: "チーム名でフィルタ（完全一致）"
+```
+
+`lib/pdca_cli/cli.rb:882-885` の `client.dashboard_weekly(...)` 呼び出しを以下に変更:
+```ruby
+result = client.dashboard_weekly(
+  week_offset: options[:week_offset],
+  team: options[:team]
+)
+```
+
+- [ ] **Step 5: Ruby構文チェック**
+
+```bash
+ruby -c lib/pdca_cli/cli.rb
+```
+
+Expected: `Syntax OK`
+
+- [ ] **Step 6: 旧オプション `--team_id` が残っていないことを確認**
+
+```bash
+grep -n "team_id" lib/pdca_cli/cli.rb
+```
+
+Expected: 何も出力されない（0件）
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add lib/pdca_cli/cli.rb
+git commit -m "feat: 講師向けコマンドの --team_id を --team（チーム名）に変更 (#29)"
+```
+
+---
+
+## Task 3: CLAUDE.md の使用例を更新
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: CLAUDE.md 内の `--team_id` 記載を確認**
+
+```bash
+grep -n "team_id" CLAUDE.md
+```
+
+各行の前後を確認し、以下の置換対象を特定する（`--category_ids` は別機能なので対象外）。
+
+- [ ] **Step 2: `student list` のセクションを更新**
+
+`bin/pdca student list --json`、`bin/pdca student list --status active --json` の記載は維持したまま、チーム関連の使用例を以下のように追加（既存にチーム例が無ければ追加、あれば差し替え）:
+
+```bash
+bin/pdca student list --team "Aチーム" --json
+```
+
+- [ ] **Step 3: `progress list` のセクションを更新**
+
+同様に:
+
+```bash
+bin/pdca progress list --team "Aチーム" --json
+```
+
+- [ ] **Step 4: `dashboard daily` / `dashboard weekly` のセクションを更新**
+
+もしチーム例が記載されていれば、`--team_id N` を `--team "チーム名"` に置換。記載が無ければ追記不要。
+
+- [ ] **Step 5: 最終確認**
+
+```bash
+grep -n "team_id" CLAUDE.md
+```
+
+Expected: `--category_ids` 以外に `team_id` が残っていない
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: CLAUDE.md のチームフィルタ例を --team（名前指定）に更新 (#29)"
+```
+
+---
+
+## Task 4: 手動動作確認
+
+**前提:** API側のPRがマージされ、本番環境（Heroku）に `team_name` パラメータ対応がデプロイ済みであること。未デプロイの場合は、ローカルAPI環境（`PDCA_API_URL` 環境変数で切り替え）で確認する。
+
+- [ ] **Step 1: ヘルプ表示で新オプションが反映されているか確認**
+
+```bash
+bin/pdca student list --help
+```
+
+Expected: `--team=TEAM` が表示され、`--team_id` は表示されない。
+
+同様に:
+```bash
+bin/pdca progress list --help
+bin/pdca dashboard daily --help
+bin/pdca dashboard weekly --help
+```
+
+- [ ] **Step 2: `student list --team` の動作確認**
+
+```bash
+bin/pdca student list --json
+```
+
+JSON出力から任意のチーム名を取得し（`students[*].teams[0]`）、そのチーム名で絞り込み:
+
+```bash
+bin/pdca student list --team "取得したチーム名" --json
+```
+
+Expected: 指定チームに所属する受講生のみが返る。
+
+- [ ] **Step 3: 存在しないチーム名で空配列が返ることを確認**
+
+```bash
+bin/pdca student list --team "__not_existing_team_xyz__" --json
+```
+
+Expected: `{"students":[],"total":0,...}` のように空配列で正常終了（exit code 0）。
+
+- [ ] **Step 4: `progress list --team` の動作確認**
+
+```bash
+bin/pdca progress list --team "取得したチーム名" --json
+```
+
+Expected: 指定チームの進捗のみが返る。
+
+- [ ] **Step 5: `dashboard daily --team` の動作確認**
+
+```bash
+bin/pdca dashboard daily --team "取得したチーム名" --json
+```
+
+Expected: 指定チームの日別報告状況のみが返る。
+
+- [ ] **Step 6: `dashboard weekly --team` の動作確認**
+
+```bash
+bin/pdca dashboard weekly --team "取得したチーム名" --json
+```
+
+Expected: 指定チームの週別報告状況のみが返る。
+
+- [ ] **Step 7: 動作確認結果のメモ**
+
+コマンド実行結果をPRの説明文に貼り付けできるようメモしておく。問題があればTask 1-3に戻って修正。
+
+---
+
+## Task 5: PR作成
+
+**Files:**
+- なし（GitHub操作のみ）
+
+- [ ] **Step 1: ブランチをリモートにpush**
+
+```bash
+git push -u origin feature/i29-team-name-filter
+```
+
+- [ ] **Step 2: CLI側PRを作成**
+
+```bash
+gh pr create --title "feat: 講師向けコマンドのチームフィルタを --team（名前指定）に変更 (#29)" --body "$(cat <<'EOF'
+## 概要
+
+[Issue #29](https://github.com/koki-kato/pdca-app/issues/29) 対応。講師向けコマンドのチームフィルタを `--team_id N` から `--team "チーム名"` に完全置換。
+
+## 変更内容
+
+- `lib/pdca_cli/client.rb`: 4メソッドの `team_id:` 引数を `team:` に変更、APIへは `team_name` パラメータとして送信
+- `lib/pdca_cli/cli.rb`: 4コマンド（student list / progress list / dashboard daily / dashboard weekly）の `--team_id` オプションを `--team` に置換
+- `CLAUDE.md`: 使用例を更新
+- `docs/superpowers/specs/2026-04-17-team-name-filter-design.md`: 設計ドキュメント
+- `docs/superpowers/plans/2026-04-17-team-name-filter.md`: 実装計画
+
+## 前提
+
+**API側 PR（別リポジトリ `occ_pdca_app`）** のマージ・本番デプロイが先。API側でCLI側PR（本PR）へのリンクを貼っているはずなので相互参照してください。
+
+## テスト方針
+
+既存プロジェクトにテストディレクトリが無いため、手動動作確認で検証（過去の講師向け機能追加 #14/#15/#20 と同じ方針）。
+
+## Test plan
+
+- [ ] `bin/pdca student list --help` で `--team` オプションが表示される
+- [ ] `bin/pdca student list --team "チーム名" --json` でフィルタが機能する
+- [ ] `bin/pdca progress list --team "チーム名" --json` でフィルタが機能する
+- [ ] `bin/pdca dashboard daily --team "チーム名" --json` でフィルタが機能する
+- [ ] `bin/pdca dashboard weekly --team "チーム名" --json` でフィルタが機能する
+- [ ] 存在しないチーム名指定で空配列が返る
+
+## 関連
+
+- API側PR: （API側PR作成後にリンク追記）
+EOF
+)"
+```
+
+- [ ] **Step 3: API側PRへのリンクを追記（API側PR作成後）**
+
+API側PRを作成したら、本PRの説明文の「関連」セクションにAPI側PRのURLを追記する:
+
+```bash
+gh pr edit --body "$(gh pr view --json body -q .body | sed 's|（API側PR作成後にリンク追記）|https://github.com/koki-kato/occ_pdca_app/pull/XXX|')"
+```
+
+または手動でGitHub UIから編集。
+
+---
+
+## 完了基準
+
+- [ ] Task 1-5 の全ステップが完了
+- [ ] API側PRがマージ・デプロイされている
+- [ ] CLI側PRがレビュー通過
+- [ ] 手動動作確認で4コマンド全てフィルタが機能する
+- [ ] Issue #29 がClose可能な状態

--- a/docs/superpowers/specs/2026-04-17-team-name-filter-design.md
+++ b/docs/superpowers/specs/2026-04-17-team-name-filter-design.md
@@ -1,0 +1,170 @@
+# 講師向けコマンドのチームフィルタを名前指定に変更
+
+- **Issue**: [#29](https://github.com/koki-kato/pdca-app/issues/29)
+- **作成日**: 2026-04-17
+- **ステータス**: 設計完了（実装前）
+- **対象リポジトリ**:
+  - CLI: `pdca-cli`（このリポジトリ）
+  - API: `occ_pdca_app`（別リポジトリ、連動PR必須）
+
+## 目的
+
+講師向けコマンドのチームフィルタを、覚えにくいID指定（`--team_id 5`）から直感的な名前指定（`--team "Aチーム"`）に変更する。CLI直接実行時のUXを向上させる。
+
+## 背景
+
+Issue #14 (I1) および Issue #20 (I7) では当初 `--team "チーム名"` として設計されていたが、API側が `team_id` のみ対応だったため、暫定的に `--team_id` として実装された。本改修でAPIに `team_name` パラメータを追加し、CLIを当初の設計に揃える。
+
+Claude Code経由で使う場合は `student list --json` からチーム名を取得して完全一致で投げる運用が自然なため、名前検索の方が親和性が高い。
+
+## スコープ
+
+### 対象コマンド（4つ）
+
+Issue #29 本文では `student list` と `progress list` のみが対象だが、CLIのUX一貫性を重視し、`--team_id` を使用している全コマンドを一括変更する。
+
+- `pdca student list`
+- `pdca progress list`
+- `pdca dashboard daily`
+- `pdca dashboard weekly`
+
+### 対象外
+
+- 上記以外のコマンド（`--team_id` を使っていない）
+
+## 設計方針
+
+### 1. CLIオプションの変更
+
+`--team_id`（数値） → `--team`（文字列）に**完全置換**。後方互換は持たない。
+
+- 理由: CLIはまだ新しく、利用者が限定的。2つのオプションが混在すると将来的な技術的負債になる。
+
+### 2. APIパラメータの変更
+
+`team_name` パラメータを**追加**し、既存の `team_id` は**当面残す**（後方互換）。
+
+- 理由: Web側（`StudentsController` 等）が内部で `team_id` を使用している可能性があり、Web機能を壊さないため。
+- `team_id` と `team_name` が両方指定された場合: 両方の条件で AND 絞り込み（自然な挙動）。
+
+### 3. 検索方式
+
+**完全一致**（`WHERE teams.name = ?`）。
+
+- 理由: 講師はチーム名を正確に把握している前提でよい（`student list --json` 等で確認可能）。部分一致は「Aチーム」と「AAチーム」の混同リスクがある。将来的に部分一致が必要になれば別オプション（`--team-contains` 等）で追加可能。
+
+### 4. エッジケース
+
+- **存在しないチーム名**: 空配列を返す（エラーにしない）
+  - 理由: 「フィルタ結果が0件」と「該当チームが存在しない」はユーザー視点では同じ。
+- **同名チームが複数存在**: 該当する全チームの受講生を返す（DB上 unique 制約が無い場合）
+  - 要確認: API側で `teams.name` に unique 制約があるか。ある場合はこの考慮は不要。
+- **空文字列 `--team ""`**: フィルタ無しとして扱う（Ruby的に `""` はtruthyなので `if team && !team.empty?` でガード）
+
+## 実装内容
+
+### CLI側（pdca-cli）
+
+#### `lib/pdca_cli/cli.rb`（4箇所）
+
+オプション定義とメソッド呼び出しを変更。
+
+```ruby
+# Before
+option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+client.list_students(status: options[:status], team_id: options[:team_id])
+
+# After
+option :team, type: :string, desc: "チーム名でフィルタ（完全一致）"
+client.list_students(status: options[:status], team: options[:team])
+```
+
+#### `lib/pdca_cli/client.rb`（4メソッド）
+
+メソッドシグネチャとクエリパラメータを変更。APIには `team_name` として送る。
+
+```ruby
+# Before
+def list_students(status: nil, team_id: nil)
+  query = {}
+  query[:status] = status if status
+  query[:team_id] = team_id if team_id
+  get("/api/v1/instructor/students", query)
+end
+
+# After
+def list_students(status: nil, team: nil)
+  query = {}
+  query[:status] = status if status
+  query[:team_name] = team if team && !team.empty?
+  get("/api/v1/instructor/students", query)
+end
+```
+
+対象メソッド:
+- `list_students`
+- `list_progress`
+- `dashboard_daily`
+- `dashboard_weekly`
+
+#### `CLAUDE.md` の更新
+
+`--team_id N` の記載を `--team "チーム名"` に更新（4コマンド分）。
+
+### API側（occ_pdca_app）
+
+CLI側のPRと連動させる。PR説明に CLI 側 PR へのリンクを記載。
+
+#### 変更対象コントローラ
+
+- `app/controllers/api/v1/instructor/students_controller.rb`
+- `app/controllers/api/v1/instructor/progress_controller.rb`
+- `app/controllers/api/v1/instructor/dashboard_controller.rb`（daily/weekly両方）
+
+#### 変更内容
+
+各コントローラで `team_name` パラメータを受け付け、チーム名で join して絞り込む。`team_id` は既存のまま残す。
+
+```ruby
+# 例: students_controller.rb
+scope = User.where(role: :student)
+scope = scope.where(team_id: params[:team_id]) if params[:team_id].present?
+scope = scope.joins(:team).where(teams: { name: params[:team_name] }) if params[:team_name].present?
+```
+
+ルーティング・マイグレーションは不要（パラメータ追加のみ）。
+
+## テスト方針
+
+### CLI側（RSpec）
+
+- `spec/pdca_cli/cli_spec.rb`: 各コマンドで `--team "チーム名"` が API に `team_name=XXX` として送信されることを確認
+- `spec/pdca_cli/client_spec.rb`: クライアントメソッドが正しいクエリパラメータを生成することを確認
+- 既存の `--team_id` テストは削除（完全置換のため）
+
+### API側（RSpec）
+
+- 各コントローラの request spec に `team_name` パラメータのテストを追加
+- カバーするケース:
+  - 完全一致でフィルタできる
+  - 存在しないチーム名で空配列を返す
+  - `team_id` との AND 絞り込みが機能する
+
+## リリース順序（重要）
+
+順序を守らないと、新CLIが旧APIを叩いて `team_name` が無視され、フィルタが効かずに全件返る不具合が起きる。
+
+1. **API側を先にデプロイ**（`team_name` パラメータを受け付けられる状態に）
+2. **CLI側をリリース**（`--team` を使い始める）
+
+## PR構成
+
+- **CLI側PR**: このリポジトリに作成
+- **API側PR**: `occ_pdca_app` に作成し、CLI側PRへのリンクを記載
+- 両PR の説明文に相互リンクを貼り、レビュー時に連動していることを明示
+
+## 未決事項
+
+- API側 `teams` テーブルの `name` カラムに unique 制約があるか要確認（実装時に調査）
+  - 制約あり: 「同名チーム複数」のエッジケース考慮不要
+  - 制約なし: 設計方針4の通り、全チームの受講生を合わせて返す

--- a/lib/pdca_cli/cli.rb
+++ b/lib/pdca_cli/cli.rb
@@ -666,12 +666,12 @@ module PdcaCli
       desc "list", "受講生一覧を表示"
       option :json, type: :boolean, default: false, desc: "JSON形式で出力"
       option :status, type: :string, desc: "ステータスでフィルタ (active/inactive)"
-      option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+      option :team, type: :string, desc: "チーム名でフィルタ（完全一致）"
       def list
         client = CLI.require_auth_from(self)
 
         begin
-          result = client.list_students(status: options[:status], team_id: options[:team_id])
+          result = client.list_students(status: options[:status], team: options[:team])
           students = result["students"]
 
           if options[:json]
@@ -744,12 +744,12 @@ module PdcaCli
 
       desc "list", "受講生の進捗一覧を表示"
       option :json, type: :boolean, default: false, desc: "JSON形式で出力"
-      option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+      option :team, type: :string, desc: "チーム名でフィルタ（完全一致）"
       def list
         client = CLI.require_auth_from(self)
 
         begin
-          result = client.list_progress(team_id: options[:team_id])
+          result = client.list_progress(team: options[:team])
           students = result["students"]
 
           if options[:json]
@@ -824,7 +824,7 @@ module PdcaCli
       desc "daily", "日別の報告状況を表示"
       option :json, type: :boolean, default: false, desc: "JSON形式で出力"
       option :date, type: :string, desc: "対象日 (YYYY-MM-DD, デフォルト: 昨日)"
-      option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+      option :team, type: :string, desc: "チーム名でフィルタ（完全一致）"
       option :status, type: :string, desc: "ステータスでフィルタ (green/yellow/red/not_submitted)"
       def daily
         client = CLI.require_auth_from(self)
@@ -832,7 +832,7 @@ module PdcaCli
         begin
           result = client.dashboard_daily(
             date: options[:date],
-            team_id: options[:team_id],
+            team: options[:team],
             status: options[:status]
           )
           summary = result["summary"]
@@ -874,14 +874,14 @@ module PdcaCli
       desc "weekly", "週別の報告状況を表示"
       option :json, type: :boolean, default: false, desc: "JSON形式で出力"
       option :week_offset, type: :numeric, default: 0, desc: "週オフセット (0=今週, -1=先週)"
-      option :team_id, type: :numeric, desc: "チームIDでフィルタ"
+      option :team, type: :string, desc: "チーム名でフィルタ（完全一致）"
       def weekly
         client = CLI.require_auth_from(self)
 
         begin
           result = client.dashboard_weekly(
             week_offset: options[:week_offset],
-            team_id: options[:team_id]
+            team: options[:team]
           )
           groups = result["meeting_day_groups"]
 

--- a/lib/pdca_cli/client.rb
+++ b/lib/pdca_cli/client.rb
@@ -98,7 +98,7 @@ module PdcaCli
     def list_students(status: nil, team: nil)
       query = {}
       query[:status] = status if status
-      query[:team_name] = team if team && !team.empty?
+      query[:team_name] = team.strip if team.to_s.strip.presence
       get("/api/v1/instructor/students", query)
     end
 
@@ -109,7 +109,7 @@ module PdcaCli
     # 講師向け: 進捗確認
     def list_progress(team: nil)
       query = {}
-      query[:team_name] = team if team && !team.empty?
+      query[:team_name] = team.strip if team.to_s.strip.presence
       get("/api/v1/instructor/progress", query)
     end
 
@@ -121,7 +121,7 @@ module PdcaCli
     def dashboard_daily(date: nil, team: nil, status: nil)
       query = {}
       query[:date] = date if date
-      query[:team_name] = team if team && !team.empty?
+      query[:team_name] = team.strip if team.to_s.strip.presence
       query[:status] = status if status
       get("/api/v1/instructor/dashboard/daily", query)
     end
@@ -129,7 +129,7 @@ module PdcaCli
     def dashboard_weekly(week_offset: nil, team: nil)
       query = {}
       query[:week_offset] = week_offset if week_offset
-      query[:team_name] = team if team && !team.empty?
+      query[:team_name] = team.strip if team.to_s.strip.presence
       get("/api/v1/instructor/dashboard/weekly", query)
     end
 

--- a/lib/pdca_cli/client.rb
+++ b/lib/pdca_cli/client.rb
@@ -95,10 +95,10 @@ module PdcaCli
     end
 
     # 講師向け: 受講生
-    def list_students(status: nil, team_id: nil)
+    def list_students(status: nil, team: nil)
       query = {}
       query[:status] = status if status
-      query[:team_id] = team_id if team_id
+      query[:team_name] = team if team && !team.empty?
       get("/api/v1/instructor/students", query)
     end
 
@@ -107,9 +107,9 @@ module PdcaCli
     end
 
     # 講師向け: 進捗確認
-    def list_progress(team_id: nil)
+    def list_progress(team: nil)
       query = {}
-      query[:team_id] = team_id if team_id
+      query[:team_name] = team if team && !team.empty?
       get("/api/v1/instructor/progress", query)
     end
 
@@ -118,18 +118,18 @@ module PdcaCli
     end
 
     # 講師向け: ダッシュボード
-    def dashboard_daily(date: nil, team_id: nil, status: nil)
+    def dashboard_daily(date: nil, team: nil, status: nil)
       query = {}
       query[:date] = date if date
-      query[:team_id] = team_id if team_id
+      query[:team_name] = team if team && !team.empty?
       query[:status] = status if status
       get("/api/v1/instructor/dashboard/daily", query)
     end
 
-    def dashboard_weekly(week_offset: nil, team_id: nil)
+    def dashboard_weekly(week_offset: nil, team: nil)
       query = {}
       query[:week_offset] = week_offset if week_offset
-      query[:team_id] = team_id if team_id
+      query[:team_name] = team if team && !team.empty?
       get("/api/v1/instructor/dashboard/weekly", query)
     end
 


### PR DESCRIPTION
## 概要

[Issue #29](https://github.com/koki-kato/pdca-cli/issues/29) 対応（CLI側）。

講師向けコマンドのチームフィルタを `--team_id N`（ID指定）から `--team "チーム名"`（名前指定）に完全置換。CLI直接実行時のUXを向上させます。

## 関連PR（同時提出）

- API側PR: [koki-kato/pdca-app#87](https://github.com/koki-kato/pdca-app/pull/87)
- 設計ドキュメント: [docs/superpowers/specs/2026-04-17-team-name-filter-design.md](docs/superpowers/specs/2026-04-17-team-name-filter-design.md)
- 実装計画: [docs/superpowers/plans/2026-04-17-team-name-filter.md](docs/superpowers/plans/2026-04-17-team-name-filter.md)

## 変更対象コマンド

- `pdca student list`
- `pdca progress list`
- `pdca dashboard daily`
- `pdca dashboard weekly`

## 変更内容

### `lib/pdca_cli/client.rb`
4メソッド（`list_students`, `list_progress`, `dashboard_daily`, `dashboard_weekly`）のキーワード引数を `team_id:` → `team:` に変更。APIへは `team_name` クエリパラメータとして送信。

```ruby
def list_students(status: nil, team: nil)
  query = {}
  query[:status] = status if status
  query[:team_name] = team if team && !team.empty?
  get("/api/v1/instructor/students", query)
end
```

### `lib/pdca_cli/cli.rb`
4コマンドのThorオプションを `--team_id`（numeric）→ `--team`（string）に変更。

```ruby
option :team, type: :string, desc: "チーム名でフィルタ（完全一致）"
```

### `CLAUDE.md`
- 4コマンドそれぞれに `--team` の使用例を追加
- 注意事項セクションに `--team` の完全一致仕様を追記

## 設計上の判断

- **完全置換**: `--team_id` は残さず完全に置き換え（CLIはまだ利用者が限定的、2オプション混在は技術的負債になるため）
- **API側の後方互換**: API側では `team_id` は残す（Web側の既存機能保護）
- **検索方式**: チーム名の完全一致（Claude Code経由なら `student list --json` で先にチーム名を取得できるため、曖昧検索より予測可能）
- **エッジケース**: 存在しないチーム名 → 空配列で正常終了（エラー扱いにしない）

## マージ順序

**API側PR（[koki-kato/pdca-app#87](https://github.com/koki-kato/pdca-app/pull/87)）のマージ・デプロイが先、本PRが後**。
順序を逆にすると、新CLIが旧APIを叩いて `team_name` が無視され、フィルタが効かず全件返る不具合になります。

## Test plan

ローカル環境（Rails sサーバー on :3001 + sqlite dev DB）で以下を確認済み：

- [x] `bin/pdca student list --help` に `--team=TEAM` が表示される（`--team_id` は消えている）
- [x] `bin/pdca student list --team "サマリーテスト班" --json` → 指定チームの受講生のみ返る（21名 → 20名）
- [x] `bin/pdca student list --team "__nonexistent__" --json` → 空配列で正常終了
- [x] `bin/pdca progress list --team "テスト１" --json` → 指定チームの受講生のみ返る（2名）
- [x] `bin/pdca dashboard daily --team "サマリーテスト班" --date 2026-02-10 --json` → 正常動作
- [x] `bin/pdca dashboard weekly --team "テスト１" --json` → 正常動作

## テスト方針

既存プロジェクトにRSpec等のテスト依存が無いため、CLI側はテストコード追加なし（過去の講師向け機能追加 #14, #15, #20 と同じ方針）。API側では +10テストを追加済み（PR #87 参照）。


## 検討事項（本PR範囲外・将来対応候補）

セルフレビューで挙がった指摘のうち、本PRでは対応せず今後の検討材料として記録：

- **旧API+新CLIの silent failure**: API側デプロイ前にユーザーが `git pull` すると、旧APIが `team_name` を無視してフィルタ無効のまま全件返る。本PRではマージ順序で運用カバー。将来的にはクライアント側でレスポンス検証して警告を出す、APIバージョン確認エンドポイントを用意する等の選択肢あり
- **whitespace-only の `--team`**: `if team && !team.empty?` は `"   "` を truthy 扱いで通してしまう。API側で空配列が返るため実害はないが、`team.strip.empty?` のほうが堅牢
- **CLAUDE.md の docs コミット分割**: `79db9d3`（使用例追加）と `d2aa1d3`（注意事項追記）が同じファイルの近接編集で2コミット。squash-mergeでない場合、履歴整理のため fixup での統合も検討可能
- **dashboard daily の組合せ使用例**: `--team` と `--status not_submitted` を同時指定した場合の挙動が CLAUDE.md に明記されていない
