### PR TITLE
feat: サーバー停止時のローカルキュー fallback (pdca-report スキル拡張)

### DIFF
--- a/.claude/skills/pdca-report/SKILL.md
+++ b/.claude/skills/pdca-report/SKILL.md
@@ -23,13 +23,13 @@ MCP ツール `mcp__pdca-mcp__whoami` を呼ぶ。
 
 ### 1.5. キュー復旧チェック（サーバー停止フォールバック）
 
-`~/.pdca-mcp/queue/` に **過去の障害時に保存されたローカルキュー**があれば、サーバー復旧した今のうちに自動で本番投稿する。
+`~/.pdca/queue/` に **過去の障害時に保存されたローカルキュー**があれば、サーバー復旧した今のうちに自動で本番投稿する。
 
 **手順**:
 
 1. キュー検出
    ```bash
-   ls ~/.pdca-mcp/queue/*.json 2>/dev/null
+   ls ~/.pdca/queue/*.json 2>/dev/null
    ```
    ディレクトリ・ファイル不在は no-op で次へ。
 
@@ -38,7 +38,7 @@ MCP ツール `mcp__pdca-mcp__whoami` を呼ぶ。
    - **本番不在** → `payload` を使って `mcp__pdca-mcp__report_create` を実行
      - 成功 → ファイル削除（`rm <path>`）
      - 失敗（5xx/network 継続）→ ファイルは残し、ユーザーに「サーバーまだ不安定です」と通知
-   - **本番あり（同日報告済）** → `mkdir -p ~/.pdca-mcp/queue/conflicts/` し当該ファイルを移動
+   - **本番あり（同日報告済）** → `mkdir -p ~/.pdca/queue/conflicts/` し当該ファイルを移動
      - 「ローカルキュー(<date>)と本番側に既存報告があります。conflicts/ に退避しました。手動マージしてください」と通知
 
 3. 同期件数を一行サマリで報告:
@@ -306,7 +306,7 @@ bin/pdca report update --date <YYYY-MM-DD> \
    mkdir -p ~/.pdca-mcp/queue
    ```
 
-2. ファイル `~/.pdca-mcp/queue/{user_id}__{operation}__{report_date}.json` に以下を保存:
+2. ファイル `~/.pdca/queue/{user_id}__{operation}__{report_date}.json` に以下を保存:
 
    ```json
    {
@@ -334,7 +334,7 @@ bin/pdca report update --date <YYYY-MM-DD> \
 
 4. ユーザーに通知:
    ```
-   ⚠️ サーバーが応答しないため、ローカルに保存しました（~/.pdca-mcp/queue/）。
+   ⚠️ サーバーが応答しないため、ローカルに保存しました（~/.pdca/queue/）。
       復旧後、次回 /pdca-report 実行時に自動送信されます（Step 1.5 で処理）。
    ```
 
@@ -439,7 +439,7 @@ bin/pdca report create --date <YYYY-MM-DD 明日> --plan <plan内容> --status g
 ユーザーが「キュー」「pending」「未送信」などと聞いたら以下を実行:
 
 ```bash
-ls ~/.pdca-mcp/queue/*.json 2>/dev/null
+ls ~/.pdca/queue/*.json 2>/dev/null
 ```
 
 各ファイルを Read して以下を一覧表示:
@@ -451,12 +451,12 @@ ls ~/.pdca-mcp/queue/*.json 2>/dev/null
 競合ファイル（手動対応待ち）は別枠で表示:
 
 ```bash
-ls ~/.pdca-mcp/queue/conflicts/*.json 2>/dev/null
+ls ~/.pdca/queue/conflicts/*.json 2>/dev/null
 ```
 
 **緊急破棄が必要な場合**:
 ```bash
-rm ~/.pdca-mcp/queue/<file>.json
+rm ~/.pdca/queue/<file>.json
 ```
 ただし破棄前に必ず `docs/reports/{date}.md` の存在確認を行い、人間用バックアップが残っていることを確認する。
 

--- a/.claude/skills/pdca-report/SKILL.md
+++ b/.claude/skills/pdca-report/SKILL.md
@@ -17,9 +17,12 @@ description: pdca-cli で日次PDCA報告を作成・更新する。未設定な
 以下を上から順に実行する。分岐は状況に応じて選ぶ。
 
 ### 1. 認証チェック
-MCP ツール `mcp__pdca-mcp__whoami` を呼ぶ。
-- 成功（user情報あり）→次へ
-- エラー → MCP のログインを試みる（`mcp__pdca-mcp__login`）。それでもダメなら CLI の `bin/pdca login` を案内して停止
+MCP ツール `mcp__pdca-mcp__whoami` を呼ぶ。エラーは status コードで分岐する:
+
+- **成功**（user情報あり）→ 次へ
+- **401 / UNAUTHORIZED** → MCP のログインを試みる（`mcp__pdca-mcp__login`）。それでもダメなら CLI の `bin/pdca login` を案内して停止
+- **5xx / NETWORK_ERROR**（サーバー側障害）→ **停止しない**。ローカル設定（`~/.pdca-mcp.json` または `~/.pdca.yml`）からキャッシュ済みの user 情報を取得し、Step 1.5 のキュー復旧と Step 8 のキュー書き込みフォールバックに進む。設定ファイルが存在しない場合のみ停止
+- **その他**（4xx 等）→ 内容をユーザーに伝えて停止
 
 ### 1.5. キュー復旧チェック（サーバー停止フォールバック）
 

--- a/.claude/skills/pdca-report/SKILL.md
+++ b/.claude/skills/pdca-report/SKILL.md
@@ -21,6 +21,34 @@ MCP ツール `mcp__pdca-mcp__whoami` を呼ぶ。
 - 成功（user情報あり）→次へ
 - エラー → MCP のログインを試みる（`mcp__pdca-mcp__login`）。それでもダメなら CLI の `bin/pdca login` を案内して停止
 
+### 1.5. キュー復旧チェック（サーバー停止フォールバック）
+
+`~/.pdca-mcp/queue/` に **過去の障害時に保存されたローカルキュー**があれば、サーバー復旧した今のうちに自動で本番投稿する。
+
+**手順**:
+
+1. キュー検出
+   ```bash
+   ls ~/.pdca-mcp/queue/*.json 2>/dev/null
+   ```
+   ディレクトリ・ファイル不在は no-op で次へ。
+
+2. 各 JSON ファイルを Read して内容を取得し、以下を判定:
+   - `mcp__pdca-mcp__report_show(date: <report_date>)` で本番側の存在確認
+   - **本番不在** → `payload` を使って `mcp__pdca-mcp__report_create` を実行
+     - 成功 → ファイル削除（`rm <path>`）
+     - 失敗（5xx/network 継続）→ ファイルは残し、ユーザーに「サーバーまだ不安定です」と通知
+   - **本番あり（同日報告済）** → `mkdir -p ~/.pdca-mcp/queue/conflicts/` し当該ファイルを移動
+     - 「ローカルキュー(<date>)と本番側に既存報告があります。conflicts/ に退避しました。手動マージしてください」と通知
+
+3. 同期件数を一行サマリで報告:
+   > 復旧キューを 3 件同期しました（うち 1 件は競合のため conflicts/ に退避）
+
+**前提**:
+- キューファイル名形式: `{user_id}__report_create__{YYYY-MM-DD}.json` または `{user_id}__report_update__{YYYY-MM-DD}.json`
+- 認証エラーが連発したら即座に処理を打ち切り、ユーザーに知らせる
+- バリデーションエラー (4xx) のキューは flush せず conflicts/ に移動して通知（payload に問題があるため自動修復不可）
+
 ### 2. 今日の報告・週次目標・学習計画・学習時間の状況を把握
 並列で取得する（MCP ツール優先）:
 - `mcp__pdca-mcp__report_today`
@@ -263,6 +291,60 @@ bin/pdca report update --date <YYYY-MM-DD> \
 
 成功したら JSON を軽くパースしてユーザーに結果を伝える（例: 「報告を送信しました。report_id: 123」）。エラーなら原因を伝えて再試行を提案。
 
+#### サーバー停止時のフォールバック（ローカルキュー保存）
+
+`report_create` / `report_update` が以下のエラーを返した場合、**諦めずにローカルキューに保存**する:
+
+- HTTP 5xx (`SERVER_ERROR`)
+- ネットワーク到達不能 (`NETWORK_ERROR`)
+- タイムアウト
+
+**手順**:
+
+1. ディレクトリ作成:
+   ```bash
+   mkdir -p ~/.pdca-mcp/queue
+   ```
+
+2. ファイル `~/.pdca-mcp/queue/{user_id}__{operation}__{report_date}.json` に以下を保存:
+
+   ```json
+   {
+     "operation": "report_create",
+     "report_date": "YYYY-MM-DD",
+     "payload": {
+       "learning_plan": "...",
+       "learning_do": "...",
+       "learning_check": "...",
+       "learning_action": "...",
+       "learning_status": "green",
+       "curriculum_name": "...",
+       "code_content": "..."
+     },
+     "queued_at": "ISO8601",
+     "user_id": <id>,
+     "user_email": "...",
+     "attempts": 0,
+     "last_error_code": "SERVER_ERROR",
+     "last_error_at": "ISO8601"
+   }
+   ```
+
+3. `study_log` / `goal_update` も同様に失敗したら `queue/` 内に同形式で別ファイル保存（operation を `study_log` / `goal_update` に変える）
+
+4. ユーザーに通知:
+   ```
+   ⚠️ サーバーが応答しないため、ローカルに保存しました（~/.pdca-mcp/queue/）。
+      復旧後、次回 /pdca-report 実行時に自動送信されます（Step 1.5 で処理）。
+   ```
+
+5. **Step 9（docs/reports/ 保存）は queue 状態でも必ず実行**（人間用バックアップとして残すため）
+
+**重要**:
+- `bin/pdca` CLI フォールバックも失敗した場合のみ queue 書き込みを行う（CLI が成功すれば queue 不要）
+- queue にあるファイルは Step 1.5 で次回起動時に自動 flush 試行される
+- バリデーションエラー (4xx) は queue しない（仕様起因のため再試行不可、ユーザーに修正を促す）
+
 #### 週次目標の進捗率を自動更新
 
 PDCA 報告の送信と同時に、Do の内容から進捗%を読み取り、週次目標の進捗率を自動更新する。
@@ -351,6 +433,32 @@ bin/pdca report create --date <YYYY-MM-DD 明日> --plan <plan内容> --status g
 ※ フラグ名は `bin/pdca report help create` で最新の仕様を確認してから使う（現状 `--date`）。
 
 スキップされた場合は何もせず終了。
+
+### 11. キュー状況確認（オプション）
+
+ユーザーが「キュー」「pending」「未送信」などと聞いたら以下を実行:
+
+```bash
+ls ~/.pdca-mcp/queue/*.json 2>/dev/null
+```
+
+各ファイルを Read して以下を一覧表示:
+- 報告日付（`report_date`）
+- 保存日時（`queued_at`）
+- 試行回数（`attempts`）
+- payload の `learning_plan` 冒頭一行
+
+競合ファイル（手動対応待ち）は別枠で表示:
+
+```bash
+ls ~/.pdca-mcp/queue/conflicts/*.json 2>/dev/null
+```
+
+**緊急破棄が必要な場合**:
+```bash
+rm ~/.pdca-mcp/queue/<file>.json
+```
+ただし破棄前に必ず `docs/reports/{date}.md` の存在確認を行い、人間用バックアップが残っていることを確認する。
 
 ## 注意事項
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,16 @@ bin/pdca report update --date 2026-04-17 --code "新しいコード" --json
 - `study log` は実績(actual)のみ対応。予定(planned)はWeb側から入力
 - `goal progress` は `--item_id + --progress`（単体）か `--progresses "id:%"`（一括）のどちらか一方を指定
 
+## サーバー停止時のフォールバック
+
+サーバー (Heroku) が 5xx を返したり接続不能な状態でも、`/pdca-report` スキル経由ならローカルに一時保存される:
+
+- 保存先: `~/.pdca-mcp/queue/`
+- 形式: `{user_id}__report_create__{YYYY-MM-DD}.json`
+- 復旧後、次回 `/pdca-report` 実行時に自動同期（本番に同日報告がなければ投稿）
+- 競合（本番側に既に同日報告あり）は `~/.pdca-mcp/queue/conflicts/` に退避
+- 人間用バックアップは `docs/reports/{date}.md` に常時保存（queue とは独立）
+
 ## 終了コード
 - 0: 成功
 - 1: 認証エラー / ネットワークエラー

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,10 +167,10 @@ bin/pdca report update --date 2026-04-17 --code "新しいコード" --json
 
 サーバー (Heroku) が 5xx を返したり接続不能な状態でも、`/pdca-report` スキル経由ならローカルに一時保存される:
 
-- 保存先: `~/.pdca-mcp/queue/`
+- 保存先: `~/.pdca/queue/`
 - 形式: `{user_id}__report_create__{YYYY-MM-DD}.json`
 - 復旧後、次回 `/pdca-report` 実行時に自動同期（本番に同日報告がなければ投稿）
-- 競合（本番側に既に同日報告あり）は `~/.pdca-mcp/queue/conflicts/` に退避
+- 競合（本番側に既に同日報告あり）は `~/.pdca/queue/conflicts/` に退避
 - 人間用バックアップは `docs/reports/{date}.md` に常時保存（queue とは独立）
 
 ## 終了コード


### PR DESCRIPTION
## Summary

- Heroku dyno 枠超過 / 5xx / network エラーで本番 API が応答しない状況でも、`/pdca-report` スキル経由の報告作成は失敗しない
- ローカルに JSON で一時保存 → 復旧後の次回起動時に自動同期（本番側に同日報告がなければ投稿）
- バイナリ（CLI/MCP）改修ではなくスキル層で対応 → 即時配布・修正容易

## 背景

2026-04-28 に Heroku Eco プランの月間 dyno hours を使い切り、pdca-app が 503 で落ちた。サイクルリセットまで 2 日あり、その間も受講生が報告できる手段が必要。

恒久対策（Basic upgrade / バイナリ実装）と並行して、即時投入できる **スキル層フォールバック**を整備する。

## 追加内容

| 節 | 内容 |
|---|---|
| Step 1.5（新規） | キュー復旧チェック。認証直後に `~/.pdca-mcp/queue/` を走査し、本番に存在しない日付分を自動 flush |
| Step 8（追加） | 送信失敗（5xx/network）時のキュー書き込み手順 |
| Step 11（新規） | `/pdca-report` 中の「キュー状況確認」サブフロー |
| CLAUDE.md | フォールバック仕様の概要を追記 |

## キュー仕様

- 保存先: `~/.pdca-mcp/queue/`
- ファイル名: `{user_id}__{operation}__{report_date}.json`
- 内容: `operation` / `payload` / `queued_at` / `attempts` / `last_error_code` 等
- 競合（本番側に同日報告あり）: `~/.pdca-mcp/queue/conflicts/` に退避し手動マージ
- バリデーションエラー（4xx）: キュー対象外（再試行不可のため）

## 設計判断（議論ポイント）

1. **スキル層 vs バイナリ層**: 即時配布・修正容易性を優先しスキル層採用。長期的にはバイナリ層への移行も視野
2. **last wins ルール**: 本番に同日報告があれば conflicts/ に退避（自動上書きしない）
3. **docs/reports/ との関係**: queue は replay 用、docs/reports/ は人間用バックアップ。両者独立に保存

## Test plan

- [ ] サーバー停止状態で `/pdca-report` を実行 → `~/.pdca-mcp/queue/` にファイル生成されることを確認
- [ ] サーバー復旧後に `/pdca-report` を再実行 → Step 1.5 で自動 flush されることを確認
- [ ] 本番に同日報告がある状態で flush → conflicts/ に退避されることを確認
- [ ] バリデーションエラー（4xx）はキューに入らないことを確認
- [ ] docs/reports/{date}.md が queue 状態でも保存されることを確認

## 関連

- 障害発生: 2026-04-28 Heroku dyno hours exhausted
- 関連検討: pdca-mcp 側のバイナリ実装は将来 issue 化予定（スキル層で実証後）